### PR TITLE
refs: add list subcommand

### DIFF
--- a/Documentation/git-refs.adoc
+++ b/Documentation/git-refs.adoc
@@ -11,6 +11,7 @@ SYNOPSIS
 [synopsis]
 git refs migrate --ref-format=<format> [--no-reflog] [--dry-run]
 git refs verify [--strict] [--verbose]
+git refs list [--head] [--branches] [--tag]
 
 DESCRIPTION
 -----------
@@ -25,6 +26,9 @@ migrate::
 
 verify::
 	Verify reference database consistency.
+list::
+	Displays references available in a local repository along with the associated
+	commit IDs.
 
 OPTIONS
 -------
@@ -56,6 +60,21 @@ The following options are specific to 'git refs verify':
 
 --verbose::
 	When verifying the reference database consistency, be chatty.
+
+The following options are specific to 'git refs verify':
+
+--head::
+
+	Show the HEAD reference, even if it would normally be filtered out.
+
+--branches::
+--tags::
+
+	Limit to local branches and local tags, respectively.  These options
+	are not mutually exclusive; when given both, references stored in
+	"refs/heads" and "refs/tags" are displayed.  Note that `--heads`
+	is a deprecated synonym for `--branches` and may be removed
+	in the future.
 
 KNOWN LIMITATIONS
 -----------------

--- a/t/meson.build
+++ b/t/meson.build
@@ -224,6 +224,7 @@ integration_tests = [
   't1450-fsck.sh',
   't1451-fsck-buffer.sh',
   't1460-refs-migrate.sh',
+  't1461-refs-list.sh',
   't1500-rev-parse.sh',
   't1501-work-tree.sh',
   't1502-rev-parse-parseopt.sh',

--- a/t/t1461-refs-list.sh
+++ b/t/t1461-refs-list.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+test_description='refs list'
+GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME=main
+export GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME
+
+. ./test-lib.sh
+
+test_expect_success setup '
+	test_commit --annotate A &&
+	git checkout -b side &&
+	test_commit --annotate B &&
+	git checkout main &&
+	test_commit C &&
+	git branch B A^0
+'
+test_expect_success 'refs list --branches, --tags, --head' '
+	for branch in B main side
+	do
+		echo $(git rev-parse refs/heads/$branch) refs/heads/$branch || return 1
+	done >expect.branches &&
+	git refs list --branches >actual &&
+	test_cmp expect.branches actual &&
+
+	for tag in A B C
+	do
+		echo $(git rev-parse refs/tags/$tag) refs/tags/$tag || return 1
+	done >expect.tags &&
+	git refs list --tags >actual &&
+	test_cmp expect.tags actual &&
+
+	cat expect.branches expect.tags >expect &&
+	git refs list --branches --tags >actual &&
+	test_cmp expect actual &&
+
+	{
+		echo $(git rev-parse HEAD) HEAD &&
+		cat expect.branches expect.tags
+	} >expect &&
+	git refs list --branches --tags --head >actual &&
+	test_cmp expect actual
+'
+
+test_expect_success 'refs list --heads is deprecated and hidden' '
+	test_expect_code 129 git refs list -h >short-help &&
+	test_grep ! -e --heads short-help &&
+	git refs list --heads >actual 2>warning &&
+	test_grep ! deprecated warning &&
+	test_cmp expect.branches actual
+'
+
+test_done


### PR DESCRIPTION
consolidate `git show-ref` command as `git refs list` along with some of the flags. Namely:
        - --branches | --heads(deprecated)
        - --head
        - --tags

So, now new subcommands can replace old ones like:
- `git show-ref [--head]` -> `git refs list [--head]`
- `git show-ref [--branches | --heads]` -> `git refs list [-branches | --heads]`
- `git show-ref [--tags]` -> `git refs list [--tags]`

Also add tests for this subcommand along with their flags.